### PR TITLE
Build CSV import interface for InvestmentImport

### DIFF
--- a/app/controllers/import/configurations_controller.rb
+++ b/app/controllers/import/configurations_controller.rb
@@ -21,6 +21,7 @@ class Import::ConfigurationsController < ApplicationController
 
     def import_params
       params.require(:import).permit(
+        :account_id,
         :date_col_label,
         :amount_col_label,
         :name_col_label,
@@ -34,6 +35,13 @@ class Import::ConfigurationsController < ApplicationController
         :entity_type_col_label,
         :notes_col_label,
         :currency_col_label,
+        :beginning_balance_col_label,
+        :deposits_and_withdrawals_col_label,
+        :market_gain_loss_col_label,
+        :income_returns_col_label,
+        :personal_investment_returns_col_label,
+        :cumulative_returns_col_label,
+        :ending_balance_col_label,
         :date_format,
         :number_format,
         :signage_convention,

--- a/app/helpers/imports_helper.rb
+++ b/app/helpers/imports_helper.rb
@@ -22,7 +22,14 @@ module ImportsHelper
       ticker: "Ticker",
       exchange: "Exchange",
       price: "Price",
-      entity_type: "Type"
+      entity_type: "Type",
+      beginning_balance: "Beginning Balance",
+      deposits_and_withdrawals: "Deposits & Withdrawals",
+      market_gain_loss: "Market Gain/Loss",
+      income_returns: "Income Returns",
+      personal_investment_returns: "Personal Investment Returns",
+      cumulative_returns: "Cumulative Returns",
+      ending_balance: "Ending Balance"
     }[key]
   end
 
@@ -31,7 +38,8 @@ module ImportsHelper
       transactions: DryRunResource.new(label: "Transactions", icon: "credit-card", text_class: "text-cyan-500", bg_class: "bg-cyan-500/5"),
       accounts: DryRunResource.new(label: "Accounts", icon: "layers", text_class: "text-orange-500", bg_class: "bg-orange-500/5"),
       categories: DryRunResource.new(label: "Categories", icon: "shapes", text_class: "text-blue-500", bg_class: "bg-blue-500/5"),
-      tags: DryRunResource.new(label: "Tags", icon: "tags", text_class: "text-violet-500", bg_class: "bg-violet-500/5")
+      tags: DryRunResource.new(label: "Tags", icon: "tags", text_class: "text-violet-500", bg_class: "bg-violet-500/5"),
+      investment_snapshots: DryRunResource.new(label: "Investment Snapshots", icon: "trending-up", text_class: "text-green-500", bg_class: "bg-green-500/5")
     }
 
     map[key]
@@ -62,7 +70,7 @@ module ImportsHelper
 
   private
     def permitted_import_types
-      %w[transaction_import trade_import account_import mint_import]
+      %w[transaction_import trade_import account_import mint_import investment_import]
     end
 
     DryRunResource = Struct.new(:label, :icon, :text_class, :bg_class, keyword_init: true)

--- a/app/views/import/configurations/_investment_import.html.erb
+++ b/app/views/import/configurations/_investment_import.html.erb
@@ -1,0 +1,35 @@
+<%# locals: (import:) %>
+
+<%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-4" do |form| %>
+  <div class="space-y-4">
+    <% unless import.account.present? %>
+      <%= form.select :account_id,
+                      Current.family.accounts.where(accountable_type: "Investment").map { |a| [a.name, a.id] },
+                      { include_blank: "Select account", label: "Account" },
+                      required: true %>
+    <% end %>
+
+    <div class="flex items-center gap-4">
+      <%= form.select :date_col_label, import.csv_headers, { include_blank: "Select column", label: "Date" }, required: true %>
+      <%= form.select :date_format,
+                      [["MM/YYYY", "%m/%Y"], ["YYYY/MM", "%Y/%m"], ["MM-YYYY", "%m-%Y"], ["YYYY-MM", "%Y-%m"]],
+                      { label: t(".date_format_label") },
+                      required: true %>
+    </div>
+
+    <%= form.select :ending_balance_col_label, import.csv_headers, { include_blank: "Select column", label: "Ending Balance" }, required: true %>
+    <%= form.select :beginning_balance_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Beginning Balance" } %>
+    <%= form.select :deposits_and_withdrawals_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Deposits & Withdrawals" } %>
+    <%= form.select :market_gain_loss_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Market Gain/Loss" } %>
+    <%= form.select :income_returns_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Income Returns" } %>
+    <%= form.select :personal_investment_returns_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Personal Investment Returns" } %>
+    <%= form.select :cumulative_returns_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Cumulative Returns" } %>
+
+    <div class="flex items-center gap-4">
+      <%= form.select :currency_col_label, import.csv_headers, { include_blank: "Default", label: "Currency" } %>
+      <%= form.select :number_format, Import::NUMBER_FORMATS.keys, { label: "Format", prompt: "Select format" }, required: true %>
+    </div>
+  </div>
+
+  <%= form.submit "Apply configuration", disabled: import.complete? %>
+<% end %>

--- a/app/views/imports/new.html.erb
+++ b/app/views/imports/new.html.erb
@@ -85,6 +85,26 @@
           </li>
         <% end %>
 
+        <% if Current.family.accounts.where(accountable_type: "Investment").any? && (params[:type].nil? || params[:type] == "InvestmentImport") %>
+          <li>
+            <%= button_to imports_path(import: { type: "InvestmentImport" }), class: "flex items-center justify-between p-4 group cursor-pointer w-full", data: { turbo: false } do %>
+              <div class="flex items-center gap-2">
+                <div class="bg-green-500/5 rounded-md w-8 h-8 flex items-center justify-center">
+                  <span class="text-green-500">
+                    <%= icon("trending-up", color: "current") %>
+                  </span>
+                </div>
+                <span class="text-sm text-primary group-hover:text-secondary">
+                  <%= t(".import_investment_snapshots") %>
+                </span>
+              </div>
+              <%= icon("chevron-right") %>
+            <% end %>
+
+            <%= render "shared/ruler" %>
+          </li>
+        <% end %>
+
         <% if Current.family.accounts.any? && (params[:type].nil? || params[:type] == "MintImport" || params[:type] == "TransactionImport") %>
           <li>
             <%= button_to imports_path(import: { type: "MintImport" }), class: "flex items-center justify-between p-4 group w-full", data: { turbo: false } do %>

--- a/config/locales/views/imports/en.yml
+++ b/config/locales/views/imports/en.yml
@@ -10,6 +10,8 @@ en:
           details.
         title: Clean your data
     configurations:
+      investment_import:
+        date_format_label: Date format
       mint_import:
         date_format_label: Date format
       show:
@@ -77,6 +79,7 @@ en:
       description: You can manually import various types of data via CSV or use one
         of our import templates like Mint.
       import_accounts: Import accounts
+      import_investment_snapshots: Import investment snapshots
       import_mint: Import from Mint
       import_portfolio: Import investments
       import_transactions: Import transactions

--- a/test/fixtures/files/imports/investment_snapshots.csv
+++ b/test/fixtures/files/imports/investment_snapshots.csv
@@ -1,0 +1,3 @@
+date,beginning_balance,deposits_and_withdrawals,market_gain_loss,income_returns,personal_investment_returns,cumulative_returns,ending_balance,currency
+03/2026,10000.00,500.00,250.00,50.00,2.5,15.3,10800.00,USD
+02/2026,9500.00,0.00,500.00,25.00,2.1,12.5,10000.00,USD

--- a/test/system/imports_test.rb
+++ b/test/system/imports_test.rb
@@ -190,4 +190,46 @@ class ImportsTest < ApplicationSystemTestCase
 
     click_on "Back to dashboard"
   end
+
+  test "investment snapshot import" do
+    visit new_import_path
+
+    click_on "Import investment snapshots"
+
+    within_testid("import-tabs") do
+      click_on "Copy & Paste"
+    end
+
+    fill_in "import[raw_file_str]", with: file_fixture("imports/investment_snapshots.csv").read
+
+    within "form" do
+      click_on "Upload CSV"
+    end
+
+    # Select account first (since none was set at creation time)
+    select "Robinhood Brokerage Account", from: "import[account_id]"
+
+    # Map CSV columns to import fields
+    # CSV headers: date, beginning_balance, deposits_and_withdrawals, market_gain_loss, income_returns, personal_investment_returns, cumulative_returns, ending_balance, currency
+    select "date", from: "import[date_col_label]"
+    select "MM/YYYY", from: "import[date_format]"
+    select "ending_balance", from: "import[ending_balance_col_label]"
+    select "currency", from: "import[currency_col_label]"
+
+    click_on "Apply configuration"
+
+    click_on "Next step"
+
+    click_on "Publish import"
+
+    assert_text "Import in progress"
+
+    perform_enqueued_jobs
+
+    click_on "Check status"
+
+    assert_text "Import successful"
+
+    click_on "Back to dashboard"
+  end
 end


### PR DESCRIPTION
## Summary
Completes issue #88 by implementing the CSV import interface for monthly investment snapshots.

Users can now:
- Select "Import investment snapshots" from the type selection screen
- Configure column mappings for date, ending balance, and optional investment performance fields
- Import monthly investment snapshots through the standard multi-step import wizard

## What's included
- Configuration partial with account selection and monthly date formats
- Integration into type selection view with green trending-up icon
- Helper updates for column labels and dry-run display
- Comprehensive system test covering full workflow
- Fixture CSV file for testing

## Tests
- All 33 existing + new tests pass (28 model + 5 system)
- All linters pass (rubocop, erb_lint)
- System test verifies full import flow: upload → configure → clean → publish → success

Closes #88